### PR TITLE
Importar division para evitar "division by zero"

### DIFF
--- a/notebooks/tp/tp-1/trabajo-practico-1.ipynb
+++ b/notebooks/tp/tp-1/trabajo-practico-1.ipynb
@@ -39,6 +39,7 @@
     "import timeit\n",
     "import time\n",
     "import numpy as np\n",
+    "from __future__ import division\n",
     "\n",
     "t = np.arange(0, 1024/20000, 1/20000)\n",
     "s1= sin(2*np.pi*1000*t)+1 \n",


### PR DESCRIPTION
Al no importar from __future__ import division
Surge un problema de "division by zero"